### PR TITLE
29 encapsulate arnoldi iteration

### DIFF
--- a/src/modified_gram_schmidt_arnoldi.m
+++ b/src/modified_gram_schmidt_arnoldi.m
@@ -1,0 +1,82 @@
+function [H, v, W] = modified_gram_schmidt_arnoldi(A, v, m)
+    % Modified Gram-Schmidt Arnoldi iteration
+    %
+    %   Description:
+    %   ------------
+    %
+    %   TODO: Add a brief description...
+    %
+    %   Syntaxis:
+    %   ---------
+    %
+    %   [H, W] = modified_gram_schmidt_arnoldi(A, v, m)
+    %
+    %   Input parameters:
+    %   -----------------
+    %
+    %   A:  n-by-n matrix
+    %       Matrix of coefficients.
+    %
+    %   v:  n-by-1 vector
+    %       Normalized residual vector.
+    %
+    %   m:  int
+    %       Restart parameter.
+    %
+    %   Output parameters:
+    %   ------------------
+    %
+    %   H:  size?
+    %       Upper Hessenberg matrix
+    %
+    %   W:  size?
+    %       Orthonormal basis of Krylov subspace
+    %
+    %   v:  n-b1-1 vector
+    %       Updated normalized residual vector.
+    %
+    %   Copyright:
+    %   ----------
+    %
+    %   This file is part of the KrySBAS MATLAB Toolbox.
+    %
+    %   Copyright 2023 CC&MA - NIDTec - FP - UNA
+    %
+    %   KrySBAS is free software: you can redistribute it and/or modify it under
+    %   the terms of the GNU General Public License as published by the Free
+    %   Software Foundation, either version 3 of the License, or (at your
+    %   option) any later version.
+    %
+    %   KrySBAS is distributed in the hope that it will be useful, but WITHOUT
+    %   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    %   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    %   for more details.
+    %
+    %   You should have received a copy of the GNU General Public License along
+    %   with this file.  If not, see <http://www.gnu.org/licenses/>.
+    %
+
+    % Modified Gram Schmidt-Arnoldi
+    for j = 1:m
+        w(:, j) = A * v(:, j);
+        for i = 1:j
+            h(i, j) = w(:, j)' * v(:, i);
+            w(:, j) = w(:, j) - h(i, j) * v(:, i);
+        end
+        h(j + 1, j) = norm(w(:, j));
+        if h(j + 1, j) == 0
+            m = j;
+            h2 = zeros(m + 1, m); % Comment by JCC: VERIFY!!! (why?)
+            for k = 1:m
+                h2(:, k) = h(:, k);
+            end
+            h = h2;
+        else
+            v(:, j + 1) = w(:, j) / h(j + 1, j);
+        end
+    end
+
+    H = h;
+    W = w;
+
+end

--- a/src/modified_gram_schmidt_arnoldi.m
+++ b/src/modified_gram_schmidt_arnoldi.m
@@ -1,4 +1,4 @@
-function [H, V] = modified_gram_schmidt_arnoldi(A, v1, m)
+function [H, V] = modified_gram_schmidt_arnoldi(A, v, m)
     % Modified Gram-Schmidt Arnoldi iteration
     %
     %   Description:
@@ -10,7 +10,7 @@ function [H, V] = modified_gram_schmidt_arnoldi(A, v1, m)
     %   Syntaxis:
     %   ---------
     %
-    %   [H, V] = modified_gram_schmidt_arnoldi(A, v1, m)
+    %   [H, V] = modified_gram_schmidt_arnoldi(A, v, m)
     %
     %   Input parameters:
     %   -----------------
@@ -18,7 +18,7 @@ function [H, V] = modified_gram_schmidt_arnoldi(A, v1, m)
     %   A:  n-by-n matrix
     %       Matrix of coefficients.
     %
-    %   v1: n-by-1 vector
+    %   v:  n-by-1 vector
     %       Normalized residual vector.
     %
     %   m:  int
@@ -61,14 +61,14 @@ function [H, V] = modified_gram_schmidt_arnoldi(A, v1, m)
     %   with this file.  If not, see <http://www.gnu.org/licenses/>.
     %
 
-    % Initialize H and W
+    % Initialize matrices H and W
     [n, ~] = size(A);
-    H = zeros(m+1, m);
-    W = zeros(n, m);
-    
-    % Construct V matrix
+    H = zeros(m + 1, m);
+    W = zeros(n, m);  %  W is only used internally by the algorithm
+
+    % Construct the V matrix
     V = zeros(n, m + 1);
-    V(:, 1) = v1;
+    V(:, 1) = v;  % this would be v1 if one follows Ref. [1].
 
     % Modified Gram Schmidt-Arnoldi
     for j = 1:m
@@ -78,17 +78,18 @@ function [H, V] = modified_gram_schmidt_arnoldi(A, v1, m)
             W(:, j) = W(:, j) - H(i, j) * V(:, i);
         end
         H(j + 1, j) = norm(W(:, j));
-        
+
         if H(j + 1, j) == 0
             % We have reached convergence. No need to continue.
             m = j;
+            % Slice matrices and return outputs.
             H = H(1:m + 1, 1:m);
             V = V(:, 1:m);
             return
         else
             V(:, j + 1) = W(:, j) / H(j + 1, j);
         end
-    
+
     end
 
     % Slice matrix V since we are only interested in the first 'm' columns

--- a/src/modified_gram_schmidt_arnoldi.m
+++ b/src/modified_gram_schmidt_arnoldi.m
@@ -1,15 +1,16 @@
-function [H, v, W] = modified_gram_schmidt_arnoldi(A, v, m)
+function [H, V] = modified_gram_schmidt_arnoldi(A, v1, m)
     % Modified Gram-Schmidt Arnoldi iteration
     %
     %   Description:
     %   ------------
     %
-    %   TODO: Add a brief description...
+    %   Implementation of the modified Gram-Schmidt Arnoldi iteration
+    %   following [1], Algorithm 6.2.
     %
     %   Syntaxis:
     %   ---------
     %
-    %   [H, W] = modified_gram_schmidt_arnoldi(A, v, m)
+    %   [H, V] = modified_gram_schmidt_arnoldi(A, v1, m)
     %
     %   Input parameters:
     %   -----------------
@@ -17,7 +18,7 @@ function [H, v, W] = modified_gram_schmidt_arnoldi(A, v, m)
     %   A:  n-by-n matrix
     %       Matrix of coefficients.
     %
-    %   v:  n-by-1 vector
+    %   v1: n-by-1 vector
     %       Normalized residual vector.
     %
     %   m:  int
@@ -26,14 +27,18 @@ function [H, v, W] = modified_gram_schmidt_arnoldi(A, v, m)
     %   Output parameters:
     %   ------------------
     %
-    %   H:  size?
+    %   H:  m+1-by-m matrix
     %       Upper Hessenberg matrix
     %
-    %   W:  size?
+    %   V:  n-by-m matrix
     %       Orthonormal basis of Krylov subspace
     %
-    %   v:  n-b1-1 vector
-    %       Updated normalized residual vector.
+    %   References:
+    %   -----------
+    %
+    %   [1] Saad, Y. (2003). Iterative methods for sparse linear systems.
+    %   Society for Industrial and Applied Mathematics.
+    %
     %
     %   Copyright:
     %   ----------
@@ -56,27 +61,36 @@ function [H, v, W] = modified_gram_schmidt_arnoldi(A, v, m)
     %   with this file.  If not, see <http://www.gnu.org/licenses/>.
     %
 
+    % Initialize H and W
+    [n, ~] = size(A);
+    H = zeros(m+1, m);
+    W = zeros(n, m);
+    
+    % Construct V matrix
+    V = zeros(n, m + 1);
+    V(:, 1) = v1;
+
     % Modified Gram Schmidt-Arnoldi
     for j = 1:m
-        w(:, j) = A * v(:, j);
+        W(:, j) = A * V(:, j);
         for i = 1:j
-            h(i, j) = w(:, j)' * v(:, i);
-            w(:, j) = w(:, j) - h(i, j) * v(:, i);
+            H(i, j) = W(:, j)' * V(:, i);
+            W(:, j) = W(:, j) - H(i, j) * V(:, i);
         end
-        h(j + 1, j) = norm(w(:, j));
-        if h(j + 1, j) == 0
+        H(j + 1, j) = norm(W(:, j));
+        
+        if H(j + 1, j) == 0
+            % We have reached convergence. No need to continue.
             m = j;
-            h2 = zeros(m + 1, m); % Comment by JCC: VERIFY!!! (why?)
-            for k = 1:m
-                h2(:, k) = h(:, k);
-            end
-            h = h2;
+            H = H(1:m + 1, 1:m);
+            V = V(:, 1:m);
+            return
         else
-            v(:, j + 1) = w(:, j) / h(j + 1, j);
+            V(:, j + 1) = W(:, j) / H(j + 1, j);
         end
+    
     end
 
-    H = h;
-    W = w;
-
+    % Slice matrix V since we are only interested in the first 'm' columns
+    V = V(1:n, 1:m);
 end

--- a/src/pd_gmres.m
+++ b/src/pd_gmres.m
@@ -292,11 +292,13 @@ function [x, flag, relres, iter, resvec, restarted, time] = ...
         end
 
         mIteration(iter(size(iter, 1), :) + 1, 1) = m;
+        
+        % Compute normalized residual vector
         r = b - A * xInitial;
         beta = norm(r);
         v1 = r / beta;
 
-        % Apply modified Gram-Schmidt Arnoldi
+        % Modifed Gram-Schmidt Arnoldi iteration
         [H, V] = modified_gram_schmidt_arnoldi(A, v1, m);
 
         g = zeros(m + 1, 1);

--- a/src/pd_gmres.m
+++ b/src/pd_gmres.m
@@ -292,7 +292,7 @@ function [x, flag, relres, iter, resvec, restarted, time] = ...
         end
 
         mIteration(iter(size(iter, 1), :) + 1, 1) = m;
-        
+
         % Compute normalized residual vector
         r = b - A * xInitial;
         beta = norm(r);

--- a/src/pd_gmres.m
+++ b/src/pd_gmres.m
@@ -299,25 +299,29 @@ function [x, flag, relres, iter, resvec, restarted, time] = ...
         v(:, 1) = r / beta;
         h = zeros(m + 1, m);
 
-        % Modified Gram Schmidt-Arnoldi
-        for j = 1:m
-            w(:, j) = A * v(:, j);
-            for i = 1:j
-                h(i, j) = w(:, j)' * v(:, i);
-                w(:, j) = w(:, j) - h(i, j) * v(:, i);
-            end
-            h(j + 1, j) = norm(w(:, j));
-            if h(j + 1, j) == 0
-                m = j;
-                h2 = zeros(m + 1, m); % Comment by JCC: VERIFY!!! (why?)
-                for k = 1:m
-                    h2(:, k) = h(:, k);
-                end
-                h = h2;
-            else
-                v(:, j + 1) = w(:, j) / h(j + 1, j);
-            end
-        end
+        % % Modified Gram Schmidt-Arnoldi
+        % for j = 1:m
+        %     w(:, j) = A * v(:, j);
+        %     for i = 1:j
+        %         h(i, j) = w(:, j)' * v(:, i);
+        %         w(:, j) = w(:, j) - h(i, j) * v(:, i);
+        %     end
+        %     h(j + 1, j) = norm(w(:, j));
+        %     if h(j + 1, j) == 0
+        %         m = j;
+        %         h2 = zeros(m + 1, m); % Comment by JCC: VERIFY!!! (why?)
+        %         for k = 1:m
+        %             h2(:, k) = h(:, k);
+        %         end
+        %         h = h2;
+        %     else
+        %         v(:, j + 1) = w(:, j) / h(j + 1, j);
+        %     end
+        % end
+
+        [h, v, ~] = modified_gram_schmidt_arnoldi(A, v, m);
+
+
         g = zeros(m + 1, 1);
         g(1, 1) = beta;
 


### PR DESCRIPTION
This PR encapsulates the Modified Gram-Schmidt Arnoldi block (originally located in `pd_gmres`) in a separate utility function.

The functionality remains the same, although several improvements in terms of variable naming and logic were performed.