### PR TITLE
Refactor output arguments in `pd_gmres` + tests

### DIFF
--- a/src/pd_gmres.m
+++ b/src/pd_gmres.m
@@ -1,4 +1,4 @@
-function [x, flag, relres, resvec, mvec, time] = ...
+function [x, flag, relres, relresvec, mvec, time] = ...
     pd_gmres(A, b, mInitial, mMinMax, mStep, tol, maxit, xInitial, alphaPD, ...
              varargin)
     % PD-GMRES Proportional-Derivative GMRES(m)
@@ -19,62 +19,63 @@ function [x, flag, relres, resvec, mvec, time] = ...
     %   Input Parameters:
     %   -----------------
     %
-    %   A:        n-by-n matrix
-    %             Left-hand side of the linear system Ax = b.
+    %   A:          n-by-n matrix
+    %               Left-hand side of the linear system Ax = b.
     %
-    %   b:        n-by-1 vector
-    %             Right-hand side of the linear system Ax = b.
+    %   b:          n-by-1 vector
+    %               Right-hand side of the linear system Ax = b.
     %
-    %   mInitial: int, optional
-    %             Initial restart parameter (similar to 'restart' in MATLAB). If
-    %             empty, not given, or equal to n, then mInitial is not used and
-    %             the full unrestarted gmres algorithm with maxit = min(n, 10)
-    %             is employed. Note that we require 1 <= mInitial <= n.
+    %   mInitial:   int, optional
+    %               Initial restart parameter (similar to 'restart' in MATLAB).
+    %               If empty, not given, or equal to n, then mInitial is not
+    %               used and the full unrestarted gmres algorithm with
+    %               maxit = min(n, 10) is employed. Note that we require
+    %               1 <= mInitial <= n.
     %
-    %   mMinMax:  2-by-1 vector, optional
-    %             Minimum and maximum values of the restart paramter m. Default
-    %             is [1; n]. We require 1 <= mMinMax(1) < mMinMax(2) <= n. Note
-    %             that for large matrices (e.g., > 600), the default value
-    %             mMinMax(2) = n might require large computational resources.
+    %   mMinMax:    2-by-1 vector, optional
+    %               Minimum and maximum values of the restart paramter m.
+    %               Default is [1; n]. We require
+    %               1 <= mMinMax(1) < mMinMax(2) <= n. Note that for large
+    %               matrices (e.g., > 600), the default value mMinMax(2) = n
+    %               might require large computational resources.
     %
-    %   mStep:    int, optional
-    %             Step size for increasing the restart parameter m when
-    %             m < mMinMax(1). Default is 1 if n <= 10 and 3 otherwise.
+    %   mStep:      int, optional
+    %               Step size for increasing the restart parameter m when
+    %               m < mMinMax(1). Default is 1 if n <= 10 and 3 otherwise.
     %
-    %   tol:      float, optional
-    %             Tolerance error threshold for the relative residual norm.
-    %             Default is 1e-6.
+    %   tol:        float, optional
+    %               Tolerance error threshold for the relative residual norm.
+    %               Default is 1e-6.
     %
-    %   maxit:    int, optional
-    %             Maximum number of outer iterations.
+    %   maxit:      int, optional
+    %               Maximum number of outer iterations.
     %
-    %   xInitial: n-by-1 vector, optional
-    %             Vector of initial guess. Default is zeros(n, 1).
+    %   xInitial:   n-by-1 vector, optional
+    %               Vector of initial guess. Default is zeros(n, 1).
     %
-    %   alphaPD:  2-by-1 vector, optional
-    %             Proportional and derivative coefficients from the
-    %             proportional-derivative controller. Default is [-3, 5],
-    %             following Ref. [2].
+    %   alphaPD:    2-by-1 vector, optional
+    %               Proportional and derivative coefficients from the
+    %               proportional-derivative controller. Default is [-3, 5],
+    %               following Ref. [2].
     %
     %   Output parameters:
     %   ------------------
     %
-    %   x:        n-by-1 vector
-    %             Approximate solution of the linear system.
+    %   x:          n-by-1 vector
+    %               Approximate solution of the linear system.
     %
-    %   flag:     boolean
-    %             1 if the algorithm has converged, 0 otherwise.
+    %   flag:       boolean
+    %               1 if the algorithm has converged, 0 otherwise.
     %
-    %   relres:   scalar
-    %             Last relative residual norm.
+    %   relres:     scalar
+    %               Last relative residual norm.
     %
-    %   resvec:   (1 up to maxit)-by-1 vector
-    %             Vector of relative residual norms.
+    %   relressvec: (1 up to maxit)-by-1 vector
+    %               Vector of relative residual norms.
     %
-    %   mvec:     (1 up to maxit)-by-1 vector
-    %             Vector of restart parameter values. In case the
-    %             unrestarted algorithm is invoked, mvec = NaN.
-    %
+    %   mvec:       (1 up to maxit)-by-1 vector
+    %               Vector of restart parameter values. In case the
+    %               unrestarted algorithm is invoked, mvec = NaN.
     %
     %   References:
     %   -----------
@@ -268,7 +269,7 @@ function [x, flag, relres, resvec, mvec, time] = ...
         tic();
 
         % Calll MATLAB bult-in gmres
-        [x, flag, relres, ~, resvec] = ...
+        [x, flag, relres, ~, relresvec] = ...
             gmres(A, b, [], tol, maxit, [], [], xInitial);
 
         % gmres uses a flag system. We only care wheter the solution has
@@ -282,7 +283,7 @@ function [x, flag, relres, resvec, mvec, time] = ...
         % gmres saves the full history of residual vectors norm of every
         % iteration of gmres or gmres(m) (inner iterationes). We only save
         % the last one (per cycle).
-        resvec = [resvec(1); resvec(end)];
+        relresvec = [relresvec(1); relresvec(end)];
 
         % The vector of restart parameters is not used, return NaN
         mvec = NaN;
@@ -298,7 +299,7 @@ function [x, flag, relres, resvec, mvec, time] = ...
     restart = 1;
     r0 = b - A * xInitial;
     res(1, :) = norm(r0);
-    resvec(1, :) = (norm(r0) / res(1, 1));
+    relresvec(1, :) = (norm(r0) / res(1, 1));
     iter(1, :) = restart;
     mvec(1, 1) = mInitial;
 
@@ -356,9 +357,9 @@ function [x, flag, relres, resvec, mvec, time] = ...
         xm = xInitial + V * minimizer;
         res(restart + 1, :) = abs(g(m + 1, 1));
         iter(restart + 1, :) = restart + 1;
-        resvec(size(resvec, 1) + 1, :) = abs(g(m + 1, 1) / res(1, 1));
+        relresvec(size(relresvec, 1) + 1, :) = abs(g(m + 1, 1) / res(1, 1));
         % Use last component of g as residual
-        if abs(g(m + 1, 1)) / res(1, 1) < tol || size(resvec, 1) == maxit
+        if abs(g(m + 1, 1)) / res(1, 1) < tol || size(relresvec, 1) == maxit
             flag = 1;  % solution has converged
             x = xm;  % solution vector
         else

--- a/src/pd_gmres.m
+++ b/src/pd_gmres.m
@@ -1,4 +1,4 @@
-function [x, flag, relres, relresvec, mvec, time] = ...
+function [x, flag, relresvec, mvec, time] = ...
     pd_gmres(A, b, mInitial, mMinMax, mStep, tol, maxit, xInitial, alphaPD, ...
              varargin)
     % PD-GMRES Proportional-Derivative GMRES(m)
@@ -12,7 +12,7 @@ function [x, flag, relres, relresvec, mvec, time] = ...
     %   Signature:
     %   ----------
     %
-    %   [x, flag, relres, iter, resvec, mvec, time] = pd_gmres(A, b, ...
+    %   [x, flag, relresvec, mvec, time] = pd_gmres(A, b, ...
     %       mInitial, mMinMax, mStep, tol, maxit, xInitial, alphaPD)
     %
     %
@@ -67,15 +67,16 @@ function [x, flag, relres, relresvec, mvec, time] = ...
     %   flag:       boolean
     %               1 if the algorithm has converged, 0 otherwise.
     %
-    %   relres:     scalar
-    %               Last relative residual norm.
-    %
     %   relressvec: (1 up to maxit)-by-1 vector
-    %               Vector of relative residual norms.
+    %               Vector of relative residual norms. The last relative
+    %               residual norm is simply given by relresvec(end).
     %
     %   mvec:       (1 up to maxit)-by-1 vector
     %               Vector of restart parameter values. In case the
     %               unrestarted algorithm is invoked, mvec = NaN.
+    %
+    %   time:       scalar
+    %               Computational time in seconds.
     %
     %   References:
     %   -----------
@@ -367,8 +368,6 @@ function [x, flag, relres, relresvec, mvec, time] = ...
             xInitial = xm;  % update and restart
             restart = restart + 1;
         end
-        % Compute the relative residual
-        relres = norm(b - A * xm) / norm(b);
     end
 
     time = toc();  % record CPU time

--- a/src/pd_gmres.m
+++ b/src/pd_gmres.m
@@ -259,12 +259,26 @@ function [x, flag, relres, iter, resvec, restarted, time] = ...
     % residuals).
     if ~restarted
         tic();
+        
+        % Calll MATLAB bult-in gmres
         [x, flag, relres, iter, resvec] = ...
             gmres(A, b, [], tol, maxit, [], [], xInitial);
+        
+        % gmres uses a flag system. We only care wheter the solution has
+        % converged or not
+        if flag == 0
+            flag = 1;
+        else
+            flag = 0;
+        end
+
+        % gmres saves the full history of residual vectors. We only save
+        % the last one (per cycle).
         resvec = [resvec(1); resvec(end)];
+        
         time = toc();
         return
-    end
+   end
 
     % Restarted version of PD-GMRES
 

--- a/src/pd_gmres.m
+++ b/src/pd_gmres.m
@@ -68,7 +68,7 @@ function [x, flag, relresvec, mvec, time] = ...
     %               1 if the algorithm has converged, 0 otherwise.
     %
     %   relressvec: (1 up to maxit)-by-1 vector
-    %               Vector of relative residual norms. The last relative
+    %               Vector of relative residual norms of every outer iteration (cycles). The last relative
     %               residual norm is simply given by relresvec(end).
     %
     %   mvec:       (1 up to maxit)-by-1 vector

--- a/src/pd_gmres.m
+++ b/src/pd_gmres.m
@@ -67,10 +67,10 @@ function [x, flag, relres, resvec, mvec, time] = ...
     %
     %   relres:   scalar
     %             Last relative residual norm.
-    %   
+    %
     %   resvec:   (1 up to maxit)-by-1 vector
     %             Vector of relative residual norms.
-    %             
+    %
     %   mvec:     (1 up to maxit)-by-1 vector
     %             Vector of restart parameter values. In case the
     %             unrestarted algorithm is invoked, mvec = NaN.
@@ -266,11 +266,11 @@ function [x, flag, relres, resvec, mvec, time] = ...
     % residuals).
     if ~restarted
         tic();
-        
+
         % Calll MATLAB bult-in gmres
         [x, flag, relres, ~, resvec] = ...
             gmres(A, b, [], tol, maxit, [], [], xInitial);
-        
+
         % gmres uses a flag system. We only care wheter the solution has
         % converged or not
         if flag == 0
@@ -282,13 +282,13 @@ function [x, flag, relres, resvec, mvec, time] = ...
         % gmres saves the full history of residual vectors. We only save
         % the last one (per cycle).
         resvec = [resvec(1); resvec(end)];
-        
+
         % The vector of restart parameters is not used, return NaN
         mvec = NaN;
 
         time = toc();
         return
-   end
+    end
 
     % Restarted version of PD-GMRES
 

--- a/src/pd_gmres.m
+++ b/src/pd_gmres.m
@@ -279,7 +279,8 @@ function [x, flag, relres, resvec, mvec, time] = ...
             flag = 0;
         end
 
-        % gmres saves the full history of residual vectors. We only save
+        % gmres saves the full history of residual vectors norm of every
+        % iteration of gmres or gmres(m) (inner iterationes). We only save
         % the last one (per cycle).
         resvec = [resvec(1); resvec(end)];
 

--- a/src/pd_gmres.m
+++ b/src/pd_gmres.m
@@ -68,8 +68,9 @@ function [x, flag, relresvec, mvec, time] = ...
     %               1 if the algorithm has converged, 0 otherwise.
     %
     %   relressvec: (1 up to maxit)-by-1 vector
-    %               Vector of relative residual norms of every outer iteration (cycles). The last relative
-    %               residual norm is simply given by relresvec(end).
+    %               Vector of relative residual norms of every outer iteration
+    %               (cycles). The last relative residual norm is simply given
+    %               by relresvec(end).
     %
     %   mvec:       (1 up to maxit)-by-1 vector
     %               Vector of restart parameter values. In case the

--- a/src/pd_gmres.m
+++ b/src/pd_gmres.m
@@ -269,7 +269,7 @@ function [x, flag, relres, relresvec, mvec, time] = ...
         tic();
 
         % Calll MATLAB bult-in gmres
-        [x, flag, relres, ~, relresvec] = ...
+        [x, flag, relres, ~, resvec] = ...
             gmres(A, b, [], tol, maxit, [], [], xInitial);
 
         % gmres uses a flag system. We only care wheter the solution has
@@ -282,8 +282,9 @@ function [x, flag, relres, relresvec, mvec, time] = ...
 
         % gmres saves the full history of residual vectors norm of every
         % iteration of gmres or gmres(m) (inner iterationes). We only save
-        % the last one (per cycle).
-        relresvec = [relresvec(1); relresvec(end)];
+        % the last one (per cycle). Note that we also return the normalized
+        % residual vector.
+        relresvec = [resvec(1); resvec(end)] ./ resvec(1);
 
         % The vector of restart parameters is not used, return NaN
         mvec = NaN;

--- a/tests/test_pd_gmres.m
+++ b/tests/test_pd_gmres.m
@@ -113,16 +113,16 @@ function test_mInitial_not_given_empty_or_equal_to_n_use_unrestarted()
     b = ones(3, 1);
 
     % Only provide A and b
-    [~, ~, ~, ~, ~, restarted, ~] = pd_gmres(A, b);
-    assert(restarted == false);
+    [~, ~, ~, ~, mvec, ~] = pd_gmres(A, b);
+    assert(isnan(mvec));
 
     % Pass mInitial empty
-    [~, ~, ~, ~, ~, restarted, ~] = pd_gmres(A, b, []);
-    assert(restarted == false);
+    [~, ~, ~, ~, mvec, ~] = pd_gmres(A, b, []);
+    assert(isnan(mvec));
 
     % Pass mInitial = 3
-    [~, ~, ~, ~, ~, restarted, ~] = pd_gmres(A, b, 3);
-    assert(restarted == false);
+    [~, ~, ~, ~, mvec, ~] = pd_gmres(A, b, 3);
+    assert(isnan(mvec));
 
 end
 
@@ -132,8 +132,8 @@ function test_mInitial_given_use_restarted()
 
     A = eye(3);
     b = ones(3, 1);
-    [~, ~, ~, ~, ~, restarted, ~] = pd_gmres(A, b, 1);
-    assert(restarted == true);
+    [~, ~, ~, ~, mvec, ~] = pd_gmres(A, b, 1);
+    assert(~all(isnan(mvec)));
 
 end
 
@@ -286,40 +286,48 @@ end
 
 function test_outputs_unrestarted_identity_matrix()
     % Test whether the correct outputs are returned using an identity
-    % matrix and righ-hand-side of b's
+    % matrix when the unrestarted algorithm is called
 
+    % Setup a trivial linear system
     A = eye(3);
     b = ones(3, 1);
     
-    % Return only solution
-    x = pd_gmres(A, b);
-    assertEqual(x, ones(3, 1));
-
-    % Return solution and convergence flag
-    [x, flag] = pd_gmres(A, b);
-    assertEqual(x, ones(3, 1));
-    assert(flag == 1)
-
-    % Return solution, convergence flag, and last relative residual
-    [x, flag, relres] = pd_gmres(A, b);
+    % Call function                                             
+    [x, flag, relres, resvec, mvec, time] = pd_gmres(A, b);
+   
+    % Compare with expected outputs
     assertEqual(x, ones(3, 1));
     assert(flag == 1)
     assertEqual(relres, 0)
+    assertElementsAlmostEqual(resvec, [1.7320508075688770; 0])
+    assert(isnan(mvec))
+    assert(time > 0 && time < 5) 
+end
 
-    % Return solution, convergence flag, last relative residual, and number
-    % of iterations
-    [x, flag, relres, iter] = pd_gmres(A, b);
-    assertEqual(x, ones(3, 1));
+function test_outputs_restarted_identity_matrix()
+    % Test whether the correct outputs are returned using an identity
+    % matrix when the restarted algorithm is called
+
+    A = eye(3);
+    b = [2; 3; 4];
+    mInitial = 1;
+    mMinMax = [1; 3];
+    mStep = 1;
+    tol = 1e-9;
+    maxit = 10;
+    xInitial = zeros(3, 1);
+    alphaPD = [-3; 5];
+       
+    % Call function
+    [x, flag, relres, resvec, mvec, time] = ...
+        pd_gmres(A, b, mInitial, mMinMax, mStep, tol, maxit, xInitial, alphaPD);
+
+    % Compare with expected outputs
+    assertElementsAlmostEqual(x, [2; 3; 4]);
     assert(flag == 1)
-    assertEqual(relres, 0)
-    assertEqual(iter, [1, 1])  % do we export the number of iterations per cycle as well?
-
-    % % 
-    % [x, flag, relres, iter, resvec] = pd_gmres(A, b);
-    % assertEqual(x, ones(3, 1));
-    % assert(flag == 1)
-    % assertEqual(relres, 0)
-    % assertEqual(iter, [1, 1])
-
+    assert(relres <= tol)
+    assertElementsAlmostEqual(resvec, [1; 0])
+    assertEqual(mvec, [1; 1])
+    assert(time > 0 && time < 5) 
 
 end

--- a/tests/test_pd_gmres.m
+++ b/tests/test_pd_gmres.m
@@ -291,17 +291,17 @@ function test_outputs_unrestarted_identity_matrix()
     % Setup a trivial linear system
     A = eye(3);
     b = ones(3, 1);
-    
-    % Call function                                             
+
+    % Call function
     [x, flag, relres, resvec, mvec, time] = pd_gmres(A, b);
-   
+
     % Compare with expected outputs
     assertEqual(x, ones(3, 1));
-    assert(flag == 1)
-    assertEqual(relres, 0)
-    assertElementsAlmostEqual(resvec, [1.7320508075688770; 0])
-    assert(isnan(mvec))
-    assert(time > 0 && time < 5) 
+    assert(flag == 1);
+    assertEqual(relres, 0);
+    assertElementsAlmostEqual(resvec, [1.7320508075688770; 0]);
+    assert(isnan(mvec));
+    assert(time > 0 && time < 5);
 end
 
 function test_outputs_restarted_identity_matrix()
@@ -317,17 +317,17 @@ function test_outputs_restarted_identity_matrix()
     maxit = 10;
     xInitial = zeros(3, 1);
     alphaPD = [-3; 5];
-       
+
     % Call function
     [x, flag, relres, resvec, mvec, time] = ...
         pd_gmres(A, b, mInitial, mMinMax, mStep, tol, maxit, xInitial, alphaPD);
 
     % Compare with expected outputs
     assertElementsAlmostEqual(x, [2; 3; 4]);
-    assert(flag == 1)
-    assert(relres <= tol)
-    assertElementsAlmostEqual(resvec, [1; 0])
-    assertEqual(mvec, [1; 1])
-    assert(time > 0 && time < 5) 
+    assert(flag == 1);
+    assert(relres <= tol);
+    assertElementsAlmostEqual(resvec, [1; 0]);
+    assertEqual(mvec, [1; 1]);
+    assert(time > 0 && time < 5);
 
 end

--- a/tests/test_pd_gmres.m
+++ b/tests/test_pd_gmres.m
@@ -113,15 +113,15 @@ function test_mInitial_not_given_empty_or_equal_to_n_use_unrestarted()
     b = ones(3, 1);
 
     % Only provide A and b
-    [~, ~, ~, ~, mvec, ~] = pd_gmres(A, b);
+    [~, ~, ~, mvec, ~] = pd_gmres(A, b);
     assert(isnan(mvec));
 
     % Pass mInitial empty
-    [~, ~, ~, ~, mvec, ~] = pd_gmres(A, b, []);
+    [~, ~, ~, mvec, ~] = pd_gmres(A, b, []);
     assert(isnan(mvec));
 
     % Pass mInitial = 3
-    [~, ~, ~, ~, mvec, ~] = pd_gmres(A, b, 3);
+    [~, ~, ~, mvec, ~] = pd_gmres(A, b, 3);
     assert(isnan(mvec));
 
 end
@@ -132,7 +132,7 @@ function test_mInitial_given_use_restarted()
 
     A = eye(3);
     b = ones(3, 1);
-    [~, ~, ~, ~, mvec, ~] = pd_gmres(A, b, 1);
+    [~, ~, ~, mvec, ~] = pd_gmres(A, b, 1);
     assert(~all(isnan(mvec)));
 
 end
@@ -293,13 +293,12 @@ function test_outputs_unrestarted_identity_matrix()
     b = ones(3, 1);
 
     % Call function
-    [x, flag, relres, relresvec, mvec, time] = pd_gmres(A, b);
+    [x, flag, relresvec, mvec, time] = pd_gmres(A, b);
 
     % Compare with expected outputs
     assertElementsAlmostEqual(x, ones(3, 1));
     assert(flag == 1);
-    assertElementsAlmostEqual(relres, 0);
-    assertElementsAlmostEqual(relresvec, [1.7320508075688770; 0]);
+    assertElementsAlmostEqual(relresvec, [1; 0]);
     assert(isnan(mvec));
     assert(time > 0 && time < 5);
 end
@@ -319,13 +318,12 @@ function test_outputs_restarted_identity_matrix()
     alphaPD = [-3; 5];
 
     % Call function
-    [x, flag, relres, relresvec, mvec, time] = ...
+    [x, flag, relresvec, mvec, time] = ...
         pd_gmres(A, b, mInitial, mMinMax, mStep, tol, maxit, xInitial, alphaPD);
 
     % Compare with expected outputs
     assertElementsAlmostEqual(x, [2; 3; 4]);
     assert(flag == 1);
-    assert(relres <= tol);
     assertElementsAlmostEqual(relresvec, [1; 0]);
     assertEqual(mvec, [1; 1]);
     assert(time > 0 && time < 5);

--- a/tests/test_pd_gmres.m
+++ b/tests/test_pd_gmres.m
@@ -293,13 +293,13 @@ function test_outputs_unrestarted_identity_matrix()
     b = ones(3, 1);
 
     % Call function
-    [x, flag, relres, resvec, mvec, time] = pd_gmres(A, b);
+    [x, flag, relres, relresvec, mvec, time] = pd_gmres(A, b);
 
     % Compare with expected outputs
     assertElementsAlmostEqual(x, ones(3, 1));
     assert(flag == 1);
     assertElementsAlmostEqual(relres, 0);
-    assertElementsAlmostEqual(resvec, [1.7320508075688770; 0]);
+    assertElementsAlmostEqual(relresvec, [1.7320508075688770; 0]);
     assert(isnan(mvec));
     assert(time > 0 && time < 5);
 end
@@ -319,14 +319,14 @@ function test_outputs_restarted_identity_matrix()
     alphaPD = [-3; 5];
 
     % Call function
-    [x, flag, relres, resvec, mvec, time] = ...
+    [x, flag, relres, relresvec, mvec, time] = ...
         pd_gmres(A, b, mInitial, mMinMax, mStep, tol, maxit, xInitial, alphaPD);
 
     % Compare with expected outputs
     assertElementsAlmostEqual(x, [2; 3; 4]);
     assert(flag == 1);
     assert(relres <= tol);
-    assertElementsAlmostEqual(resvec, [1; 0]);
+    assertElementsAlmostEqual(relresvec, [1; 0]);
     assertEqual(mvec, [1; 1]);
     assert(time > 0 && time < 5);
 

--- a/tests/test_pd_gmres.m
+++ b/tests/test_pd_gmres.m
@@ -296,7 +296,7 @@ function test_outputs_unrestarted_identity_matrix()
     [x, flag, relres, resvec, mvec, time] = pd_gmres(A, b);
 
     % Compare with expected outputs
-    assertEqual(x, ones(3, 1));
+    assertElementsAlmostEqual(x, ones(3, 1));
     assert(flag == 1);
     assertEqual(relres, 0);
     assertElementsAlmostEqual(resvec, [1.7320508075688770; 0]);

--- a/tests/test_pd_gmres.m
+++ b/tests/test_pd_gmres.m
@@ -298,7 +298,7 @@ function test_outputs_unrestarted_identity_matrix()
     % Compare with expected outputs
     assertElementsAlmostEqual(x, ones(3, 1));
     assert(flag == 1);
-    assertEqual(relres, 0);
+    assertElementsAlmostEqual(relres, 0);
     assertElementsAlmostEqual(resvec, [1.7320508075688770; 0]);
     assert(isnan(mvec));
     assert(time > 0 && time < 5);

--- a/tests/test_pd_gmres.m
+++ b/tests/test_pd_gmres.m
@@ -283,3 +283,43 @@ function test_size_compatibility_between_A_and_xInitial()
         assert(matches(ME.message, msg));
     end
 end
+
+function test_outputs_unrestarted_identity_matrix()
+    % Test whether the correct outputs are returned using an identity
+    % matrix and righ-hand-side of b's
+
+    A = eye(3);
+    b = ones(3, 1);
+    
+    % Return only solution
+    x = pd_gmres(A, b);
+    assertEqual(x, ones(3, 1));
+
+    % Return solution and convergence flag
+    [x, flag] = pd_gmres(A, b);
+    assertEqual(x, ones(3, 1));
+    assert(flag == 1)
+
+    % Return solution, convergence flag, and last relative residual
+    [x, flag, relres] = pd_gmres(A, b);
+    assertEqual(x, ones(3, 1));
+    assert(flag == 1)
+    assertEqual(relres, 0)
+
+    % Return solution, convergence flag, last relative residual, and number
+    % of iterations
+    [x, flag, relres, iter] = pd_gmres(A, b);
+    assertEqual(x, ones(3, 1));
+    assert(flag == 1)
+    assertEqual(relres, 0)
+    assertEqual(iter, [1, 1])  % do we export the number of iterations per cycle as well?
+
+    % % 
+    % [x, flag, relres, iter, resvec] = pd_gmres(A, b);
+    % assertEqual(x, ones(3, 1));
+    % assert(flag == 1)
+    % assertEqual(relres, 0)
+    % assertEqual(iter, [1, 1])
+
+
+end


### PR DESCRIPTION
This PR introduces a small refactoring of the output arguments in the function `pd_gmres`. In particular, the outer and inner number of iterations `iter` and the `restarted` output parameters are no longer returned. Instead, the vector of restart parameter values `mvec` is returned.

Two unit test using identity matrices to corroborate the sanity of the output arguments (one for the unrestarted and one for the restarted version of the algorithm) are also included.

Additionally to #28, this PR also fixes #23 and fixes #18.